### PR TITLE
Update check-for-ransomware-filenames.zeek to fix bug in version check

### DIFF
--- a/scripts/check-for-ransomware-filenames.zeek
+++ b/scripts/check-for-ransomware-filenames.zeek
@@ -70,7 +70,7 @@ event Files::log_files(rec: Files::Info)
 
   # Have to test the Zeek version since the files.log changed in v5
   # See here: https://docs.zeek.org/en/master/scripts/policy/frameworks/files/deprecated-txhosts-rxhosts-connuids.zeek.html
-  @if ( Version::info$major >= 5 && Version::info$minor >= 1 )
+  @if (( Version::info$major >= 5 && Version::info$minor >= 1 ) || ( Version::info$major >= 6 ))
   # Handle the v5 files log
     # see if there were any matches
     if ( num_matches > 0 )


### PR DESCRIPTION
There was a bug in the version checking, where the new `files` log would be in effect only for .1 (or higher) releases, and would fall back to the old logic for .0 releases. This fixes it to apply to 5.1 or higher, and anything greater than 6.x, which should take care of it for the long-term.